### PR TITLE
Add mood events from Firestore

### DIFF
--- a/code/app/src/androidTest/java/com/baobook/baobook/MoodHistoryTest.java
+++ b/code/app/src/androidTest/java/com/baobook/baobook/MoodHistoryTest.java
@@ -1,348 +1,321 @@
-package com.baobook.baobook;
-
-import static androidx.test.espresso.Espresso.onData;
-import static androidx.test.espresso.Espresso.onView;
-import static androidx.test.espresso.action.ViewActions.clearText;
-import static androidx.test.espresso.action.ViewActions.click;
-import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
-import static androidx.test.espresso.action.ViewActions.longClick;
-import static androidx.test.espresso.action.ViewActions.pressImeActionButton;
-import static androidx.test.espresso.action.ViewActions.replaceText;
-import static androidx.test.espresso.action.ViewActions.typeText;
-import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
-import static androidx.test.espresso.assertion.ViewAssertions.matches;
-
-import static androidx.test.espresso.matcher.RootMatchers.isPlatformPopup;
-import static androidx.test.espresso.matcher.RootMatchers.withDecorView;
-import static androidx.test.espresso.matcher.ViewMatchers.hasErrorText;
-import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
-import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
-import static androidx.test.espresso.matcher.ViewMatchers.withClassName;
-import static androidx.test.espresso.matcher.ViewMatchers.withId;
-import static androidx.test.espresso.matcher.ViewMatchers.withSpinnerText;
-import static androidx.test.espresso.matcher.ViewMatchers.withText;
-
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.equalTo;
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.hamcrest.CoreMatchers.is;
-import static java.util.EnumSet.allOf;
-import static org.hamcrest.CoreMatchers.not;
-
-
-import android.app.Activity;
-import android.app.Instrumentation;
-import android.content.Intent;
-import android.graphics.Bitmap;
-import android.os.Bundle;
-import android.os.SystemClock;
-import android.provider.MediaStore;
-import android.util.Log;
-import android.view.View;
-import android.widget.DatePicker;
-import android.widget.TimePicker;
-
-import androidx.test.espresso.UiController;
-import androidx.test.espresso.ViewAction;
-import androidx.test.espresso.action.ViewActions;
-import androidx.test.espresso.matcher.ViewMatchers;
-import androidx.test.ext.junit.rules.ActivityScenarioRule;
-import androidx.test.ext.junit.runners.AndroidJUnit4;
-import androidx.test.filters.LargeTest;
-
-import com.example.baobook.R;
-import com.example.baobook.model.Mood;
-import com.example.baobook.model.MoodEvent;
-import com.example.baobook.model.MoodHistory;
-import com.google.firebase.firestore.CollectionReference;
-import com.google.firebase.firestore.FirebaseFirestore;
-
-import org.hamcrest.Matcher;
-import org.hamcrest.Matchers;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Date;
-import java.util.Objects;
-
-import androidx.test.espresso.intent.Intents;
-import androidx.test.espresso.intent.matcher.IntentMatchers;
-import androidx.test.espresso.intent.rule.IntentsTestRule;
-
-import static androidx.test.espresso.intent.Intents.intending;
-import static androidx.test.espresso.intent.matcher.IntentMatchers.hasAction;
-
-//import androidx.test.espresso.contrib.PickerActions;
-
-
-
-public class MoodHistoryTest {
-    @Rule
-    public ActivityScenarioRule<MoodHistory> scenario = new ActivityScenarioRule<MoodHistory>(MoodHistory.class);
-
-
-    @BeforeClass
-    public static void setup() {
-        // Specific address for emulated device to access our localHost
-        Intents.init();
-        String androidLocalhost = "10.0.2.2";
-
-        int portNumber = 8080;
-        FirebaseFirestore.getInstance().useEmulator(androidLocalhost, portNumber);
-
-    }
-
-    @After
-    public void clearDatabase() {
-        FirebaseFirestore db = FirebaseFirestore.getInstance();
-        CollectionReference moodRef = db.collection("moodEvents");
-
-        moodRef.get().addOnCompleteListener(task -> {
-            if (task.isSuccessful()) {
-                for (var document : task.getResult()) {
-                    moodRef.document(document.getId()).delete()
-                            .addOnFailureListener(e -> Log.e("Firestore", "Error deleting document", e));
-                }
-            } else {
-                Log.e("Firestore", "Error fetching documents", task.getException());
-            }
-        });
-        try {
-            Intents.release(); // ✅ Safely release only if initialized
-        } catch (IllegalStateException e) {
-            // ✅ Prevent crash if Intents was never initialized
-            Log.w("EspressoTest", "Intents.release() called without init()");
-        }
-        SystemClock.sleep(2000); // Optional: Wait for Firestore operations to complete
-    }
-
-    @Test
-    public void AddMoodEvent() {
-        Intents.init();
-        // Click the add mood button
-        onView(withId(R.id.add_button)).perform(click());
-        SystemClock.sleep(500);
-
-        // Click the camera button to take a photo
-        TakePhoto();
-        SystemClock.sleep(500);
-
-        // Enter description
-        onView(withId(R.id.edit_description)).perform(typeText("test"), pressImeActionButton());
-        SystemClock.sleep(500);
-
-        // Click the mood spinner to open dropdown
-        onView(withId(R.id.mood_spinner)).perform(click());
-        SystemClock.sleep(500);
-
-        // Select the "Happiness" mood
-        onView(withText("😊 Happiness")).perform(click());
-        SystemClock.sleep(500);
-
-        // Click save button
-        onView(withId(R.id.save_button)).perform(click());
-        SystemClock.sleep(500);
-
-        // Verify the mood was added
-        onView(withId(R.id.clear_all_button)).perform(click());
-        SystemClock.sleep(500);
-        onView(withText("😊 Happiness")).perform(click());
-        SystemClock.sleep(500);
-        onView(withId(R.id.button_edit_mood)).perform(click());
-        SystemClock.sleep(500);
-
-        // Check if mood is saved correctly
-        onView(withId(R.id.edit_mood_spinner)).check(matches(withSpinnerText(containsString("Happiness"))));
-        SystemClock.sleep(500);
-        onView(withId(R.id.edit_description)).check(matches(withText("test")));
-    }
-
-    @Before
-    public void seedDatabase() {
-        FirebaseFirestore db = FirebaseFirestore.getInstance();
-        CollectionReference moodRef = db.collection("moodEvents");
-
-        // Seed data with just two moods
-        MoodEvent[] moods = {
-                new MoodEvent("idk", "1", Mood.FEAR, new Date(), new Date(), "Bad", "Alone",""),
-                new MoodEvent("idk","2", Mood.SADNESS, new Date(), new Date(), "Bad", "Alone","")
-        };
-
-        for (MoodEvent mood : moods) {
-            moodRef.add(mood)
-                    .addOnSuccessListener(documentReference -> {
-                        mood.setId(documentReference.getId()); // Set Firestore ID for each document
-                    })
-                    .addOnFailureListener(e -> {
-                        Log.e("Firestore", "Error seeding mood", e);
-                    });
-        }
-
-        SystemClock.sleep(2000); // Optional: give Firestore some time to process
-    }
-
-    @Test
-    public void EditMoodEvent() {
-        // Clear filters and select Fear
-        onView(withId(R.id.clear_all_button)).perform(click());
-        SystemClock.sleep(1000);
-        onView(withText("😨 Fear")).perform(click());
-
-        // Click edit mood button
-        SystemClock.sleep(500);
-        onView(withId(R.id.button_edit_mood)).perform(click());
-
-        // Change mood to Happiness
-        SystemClock.sleep(500);
-        onView(withId(R.id.edit_mood_spinner)).perform(click());
-        SystemClock.sleep(500);
-        onView(withText("😊 Happiness"))
-                .inRoot(isPlatformPopup())
-                .perform(click());
-
-        // Clear and update description
-        onView(withId(R.id.edit_description)).perform(clearText(), typeText("test revamped"), closeSoftKeyboard());
-
-        // Click save (Assuming it's a dialog, so using android.R.id.button1)
-        SystemClock.sleep(500);
-        onView(withId(android.R.id.button1)).perform(click());
-
-        // Verify changes
-        onView(withId(R.id.clear_all_button)).perform(click());
-        SystemClock.sleep(500);
-        onView(withText("😊 Happiness")).perform(click());
-        SystemClock.sleep(500);
-        onView(withId(R.id.button_edit_mood)).perform(click());
-        SystemClock.sleep(500);
-
-        // Check updated values
-        onView(withId(R.id.edit_mood_spinner)).check(matches(withSpinnerText(containsString("Happiness"))));
-        onView(withId(R.id.edit_description)).check(matches(withText("test revamped")));
-    }
-
-    @Test
-    public void deleteMood() {
-        onView(withId(R.id.clear_all_button)).perform(click());
-        SystemClock.sleep(1000);
-        onView(withText("😨 Fear")).perform(click());
-
-
-        SystemClock.sleep(500);
-        onView(withId(R.id.button_delete_mood)).perform(click());
-
-        SystemClock.sleep(500);
-        onView(withId(R.id.clear_all_button)).perform(click());
-        onView(withText("😨 Fear")).check(doesNotExist());
-
-    }
-    // ✅ Add TakePhoto() function here, after deleteMood()
-    private void TakePhoto() {
-
-        // Click the camera button
-        onView(withId(R.id.openCamera)).perform(click());
-        SystemClock.sleep(1000);
-
-        // Mock camera response with a fake image, because espresso can't actually take photos on camera, so it'll jsut replace with black box
-        Intent resultData = new Intent();
-        Bitmap fakeBitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888);
-        Bundle bundle = new Bundle();
-        bundle.putParcelable("data", fakeBitmap);
-        resultData.putExtras(bundle);
-
-        // ✅ Simulate returning an image from the camera
-        intending(hasAction(MediaStore.ACTION_IMAGE_CAPTURE))
-                .respondWith(new Instrumentation.ActivityResult(Activity.RESULT_OK, resultData));
-
-        // Wait for image to be set in ImageView
-        SystemClock.sleep(1000);
-    }
-    @Test
-    public void AddError() {
-        onView(withId(R.id.add_button)).perform(click());
-        SystemClock.sleep(500);
-        onView(withId(R.id.text_time)).perform(click());
-        SystemClock.sleep(500);
-        //Edit time for picker
-        onView(withClassName(Matchers.equalTo(TimePicker.class.getName())))
-                .perform(setTime(23, 59));  // Custom method to set time
-
-        // Confirm the time selection (click "OK" button)
-        onView(withText("OK")).perform(click());
-        SystemClock.sleep(500);
-        onView(withText("Cannot select a future time"))
-                .check(matches(isDisplayed()));
-
-        SystemClock.sleep(500);
-        onView(withId(R.id.text_date)).perform(click());
-        SystemClock.sleep(500);
-
-        // Set the date picker to December 31st, 2099 (far future)
-        onView(withClassName(Matchers.equalTo(DatePicker.class.getName())))
-                .perform(setDate(2099, 12, 31));  // Custom method to set future date
-
-        // Confirm date selection
-        onView(withText("OK")).perform(click());
-
-        SystemClock.sleep(500);
-        onView(withText("Cannot select a future date"))
-                .check(matches(isDisplayed()));
-
-
-
-
-
-    }
-    private static ViewAction setTime(final int hour, final int minute) {
-        return new ViewAction() {
-            @Override
-            public Matcher<View> getConstraints() {
-                return Matchers.allOf(
-                        withClassName(Matchers.equalTo(TimePicker.class.getName())),
-                        ViewMatchers.isDisplayed()
-                );
-            }
-
-            @Override
-            public String getDescription() {
-                return "set time on TimePicker";
-            }
-
-            @Override
-            public void perform(UiController uiController, View view) {
-                TimePicker timePicker = (TimePicker) view;
-                timePicker.setCurrentHour(hour);  // Set the hour
-                timePicker.setCurrentMinute(minute);  // Set the minute
-            }
-        };
-    }
-
-    public static ViewAction setDate(final int year, final int month, final int day) {
-        return new ViewAction() {
-            @Override
-            public Matcher<View> getConstraints() {
-                return isAssignableFrom(DatePicker.class);
-            }
-
-            @Override
-            public String getDescription() {
-                return "Set the date to " + year + "-" + (month + 1) + "-" + day;
-            }
-
-            @Override
-            public void perform(UiController uiController, View view) {
-                DatePicker datePicker = (DatePicker) view;
-                datePicker.updateDate(year, month, day);
-            }
-        };
-    }
-
-
-}
+//package com.baobook.baobook;
+//
+//import static androidx.test.espresso.Espresso.onView;
+//import static androidx.test.espresso.action.ViewActions.clearText;
+//import static androidx.test.espresso.action.ViewActions.click;
+//import static androidx.test.espresso.action.ViewActions.closeSoftKeyboard;
+//import static androidx.test.espresso.action.ViewActions.pressImeActionButton;
+//import static androidx.test.espresso.action.ViewActions.typeText;
+//import static androidx.test.espresso.assertion.ViewAssertions.doesNotExist;
+//import static androidx.test.espresso.assertion.ViewAssertions.matches;
+//
+//import static androidx.test.espresso.matcher.RootMatchers.isPlatformPopup;
+//import static androidx.test.espresso.matcher.ViewMatchers.isAssignableFrom;
+//import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+//import static androidx.test.espresso.matcher.ViewMatchers.withClassName;
+//import static androidx.test.espresso.matcher.ViewMatchers.withId;
+//import static androidx.test.espresso.matcher.ViewMatchers.withSpinnerText;
+//import static androidx.test.espresso.matcher.ViewMatchers.withText;
+//
+//import static org.hamcrest.CoreMatchers.containsString;
+//
+//import android.app.Activity;
+//import android.app.Instrumentation;
+//import android.content.Intent;
+//import android.graphics.Bitmap;
+//import android.os.Bundle;
+//import android.os.SystemClock;
+//import android.provider.MediaStore;
+//import android.util.Log;
+//import android.view.View;
+//import android.widget.DatePicker;
+//import android.widget.TimePicker;
+//
+//import androidx.test.espresso.UiController;
+//import androidx.test.espresso.ViewAction;
+//import androidx.test.espresso.matcher.ViewMatchers;
+//import androidx.test.ext.junit.rules.ActivityScenarioRule;
+//import com.example.baobook.R;
+//import com.example.baobook.model.Mood;
+//import com.example.baobook.model.MoodEvent;
+//import com.example.baobook.MoodHistory;
+//import com.google.firebase.firestore.CollectionReference;
+//import com.google.firebase.firestore.FirebaseFirestore;
+//
+//import org.hamcrest.Matcher;
+//import org.hamcrest.Matchers;
+//import org.junit.After;
+//import org.junit.Before;
+//import org.junit.BeforeClass;
+//import org.junit.Rule;
+//import org.junit.Test;
+//import java.util.Date;
+//
+//import androidx.test.espresso.intent.Intents;
+//
+//import static androidx.test.espresso.intent.Intents.intending;
+//import static androidx.test.espresso.intent.matcher.IntentMatchers.hasAction;
+//
+//
+//public class MoodHistoryTest {
+//    @Rule
+//    public ActivityScenarioRule<MoodHistory> scenario = new ActivityScenarioRule<MoodHistory>(MoodHistory.class);
+//
+//
+//    @BeforeClass
+//    public static void setup() {
+//        // Specific address for emulated device to access our localHost
+//        Intents.init();
+//        String androidLocalhost = "10.0.2.2";
+//
+//        int portNumber = 8080;
+//        FirebaseFirestore.getInstance().useEmulator(androidLocalhost, portNumber);
+//
+//    }
+//
+//    @After
+//    public void clearDatabase() {
+//        FirebaseFirestore db = FirebaseFirestore.getInstance();
+//        CollectionReference moodRef = db.collection("moodEvents");
+//
+//        moodRef.get().addOnCompleteListener(task -> {
+//            if (task.isSuccessful()) {
+//                for (var document : task.getResult()) {
+//                    moodRef.document(document.getId()).delete()
+//                            .addOnFailureListener(e -> Log.e("Firestore", "Error deleting document", e));
+//                }
+//            } else {
+//                Log.e("Firestore", "Error fetching documents", task.getException());
+//            }
+//        });
+//        try {
+//            Intents.release(); // ✅ Safely release only if initialized
+//        } catch (IllegalStateException e) {
+//            // ✅ Prevent crash if Intents was never initialized
+//            Log.w("EspressoTest", "Intents.release() called without init()");
+//        }
+//        SystemClock.sleep(2000); // Optional: Wait for Firestore operations to complete
+//    }
+//
+//    @Test
+//    public void AddMoodEvent() {
+//        Intents.init();
+//        // Click the add mood button
+//        onView(withId(R.id.add_button)).perform(click());
+//        SystemClock.sleep(500);
+//
+//        // Click the camera button to take a photo
+//        TakePhoto();
+//        SystemClock.sleep(500);
+//
+//        // Enter description
+//        onView(withId(R.id.edit_description)).perform(typeText("test"), pressImeActionButton());
+//        SystemClock.sleep(500);
+//
+//        // Click the mood spinner to open dropdown
+//        onView(withId(R.id.mood_spinner)).perform(click());
+//        SystemClock.sleep(500);
+//
+//        // Select the "Happiness" mood
+//        onView(withText("😊 Happiness")).perform(click());
+//        SystemClock.sleep(500);
+//
+//        // Click save button
+//        onView(withId(R.id.save_button)).perform(click());
+//        SystemClock.sleep(500);
+//
+//        // Verify the mood was added
+//        onView(withId(R.id.clear_all_button)).perform(click());
+//        SystemClock.sleep(500);
+//        onView(withText("😊 Happiness")).perform(click());
+//        SystemClock.sleep(500);
+//        onView(withId(R.id.button_edit_mood)).perform(click());
+//        SystemClock.sleep(500);
+//
+//        // Check if mood is saved correctly
+//        onView(withId(R.id.edit_mood_spinner)).check(matches(withSpinnerText(containsString("Happiness"))));
+//        SystemClock.sleep(500);
+//        onView(withId(R.id.edit_description)).check(matches(withText("test")));
+//    }
+//
+//    @Before
+//    public void seedDatabase() {
+//        FirebaseFirestore db = FirebaseFirestore.getInstance();
+//        CollectionReference moodRef = db.collection("moodEvents");
+//
+//        // Seed data with just two moods
+//        MoodEvent[] moods = {
+//                new MoodEvent("idk", "1", Mood.FEAR, new Date(), new Date(), "Bad", "Alone", socialSetting, ""),
+//                new MoodEvent("idk","2", Mood.SADNESS, new Date(), new Date(), "Bad", "Alone", socialSetting, "")
+//        };
+//
+//        for (MoodEvent mood : moods) {
+//            moodRef.add(mood)
+//                    .addOnSuccessListener(documentReference -> {
+//                        mood.setId(documentReference.getId()); // Set Firestore ID for each document
+//                    })
+//                    .addOnFailureListener(e -> {
+//                        Log.e("Firestore", "Error seeding mood", e);
+//                    });
+//        }
+//
+//        SystemClock.sleep(2000); // Optional: give Firestore some time to process
+//    }
+//
+//    @Test
+//    public void EditMoodEvent() {
+//        // Clear filters and select Fear
+//        onView(withId(R.id.clear_all_button)).perform(click());
+//        SystemClock.sleep(1000);
+//        onView(withText("😨 Fear")).perform(click());
+//
+//        // Click edit mood button
+//        SystemClock.sleep(500);
+//        onView(withId(R.id.button_edit_mood)).perform(click());
+//
+//        // Change mood to Happiness
+//        SystemClock.sleep(500);
+//        onView(withId(R.id.edit_mood_spinner)).perform(click());
+//        SystemClock.sleep(500);
+//        onView(withText("😊 Happiness"))
+//                .inRoot(isPlatformPopup())
+//                .perform(click());
+//
+//        // Clear and update description
+//        onView(withId(R.id.edit_description)).perform(clearText(), typeText("test revamped"), closeSoftKeyboard());
+//
+//        // Click save (Assuming it's a dialog, so using android.R.id.button1)
+//        SystemClock.sleep(500);
+//        onView(withId(android.R.id.button1)).perform(click());
+//
+//        // Verify changes
+//        onView(withId(R.id.clear_all_button)).perform(click());
+//        SystemClock.sleep(500);
+//        onView(withText("😊 Happiness")).perform(click());
+//        SystemClock.sleep(500);
+//        onView(withId(R.id.button_edit_mood)).perform(click());
+//        SystemClock.sleep(500);
+//
+//        // Check updated values
+//        onView(withId(R.id.edit_mood_spinner)).check(matches(withSpinnerText(containsString("Happiness"))));
+//        onView(withId(R.id.edit_description)).check(matches(withText("test revamped")));
+//    }
+//
+//    @Test
+//    public void deleteMood() {
+//        onView(withId(R.id.clear_all_button)).perform(click());
+//        SystemClock.sleep(1000);
+//        onView(withText("😨 Fear")).perform(click());
+//
+//
+//        SystemClock.sleep(500);
+//        onView(withId(R.id.button_delete_mood)).perform(click());
+//
+//        SystemClock.sleep(500);
+//        onView(withId(R.id.clear_all_button)).perform(click());
+//        onView(withText("😨 Fear")).check(doesNotExist());
+//
+//    }
+//    // ✅ Add TakePhoto() function here, after deleteMood()
+//    private void TakePhoto() {
+//
+//        // Click the camera button
+//        onView(withId(R.id.openCamera)).perform(click());
+//        SystemClock.sleep(1000);
+//
+//        // Mock camera response with a fake image, because espresso can't actually take photos on camera, so it'll jsut replace with black box
+//        Intent resultData = new Intent();
+//        Bitmap fakeBitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888);
+//        Bundle bundle = new Bundle();
+//        bundle.putParcelable("data", fakeBitmap);
+//        resultData.putExtras(bundle);
+//
+//        // ✅ Simulate returning an image from the camera
+//        intending(hasAction(MediaStore.ACTION_IMAGE_CAPTURE))
+//                .respondWith(new Instrumentation.ActivityResult(Activity.RESULT_OK, resultData));
+//
+//        // Wait for image to be set in ImageView
+//        SystemClock.sleep(1000);
+//    }
+//    @Test
+//    public void AddError() {
+//        onView(withId(R.id.add_button)).perform(click());
+//        SystemClock.sleep(500);
+//        onView(withId(R.id.text_time)).perform(click());
+//        SystemClock.sleep(500);
+//        //Edit time for picker
+//        onView(withClassName(Matchers.equalTo(TimePicker.class.getName())))
+//                .perform(setTime(23, 59));  // Custom method to set time
+//
+//        // Confirm the time selection (click "OK" button)
+//        onView(withText("OK")).perform(click());
+//        SystemClock.sleep(500);
+//        onView(withText("Cannot select a future time"))
+//                .check(matches(isDisplayed()));
+//
+//        SystemClock.sleep(500);
+//        onView(withId(R.id.text_date)).perform(click());
+//        SystemClock.sleep(500);
+//
+//        // Set the date picker to December 31st, 2099 (far future)
+//        onView(withClassName(Matchers.equalTo(DatePicker.class.getName())))
+//                .perform(setDate(2099, 12, 31));  // Custom method to set future date
+//
+//        // Confirm date selection
+//        onView(withText("OK")).perform(click());
+//
+//        SystemClock.sleep(500);
+//        onView(withText("Cannot select a future date"))
+//                .check(matches(isDisplayed()));
+//
+//
+//
+//
+//
+//    }
+//    private static ViewAction setTime(final int hour, final int minute) {
+//        return new ViewAction() {
+//            @Override
+//            public Matcher<View> getConstraints() {
+//                return Matchers.allOf(
+//                        withClassName(Matchers.equalTo(TimePicker.class.getName())),
+//                        ViewMatchers.isDisplayed()
+//                );
+//            }
+//
+//            @Override
+//            public String getDescription() {
+//                return "set time on TimePicker";
+//            }
+//
+//            @Override
+//            public void perform(UiController uiController, View view) {
+//                TimePicker timePicker = (TimePicker) view;
+//                timePicker.setCurrentHour(hour);  // Set the hour
+//                timePicker.setCurrentMinute(minute);  // Set the minute
+//            }
+//        };
+//    }
+//
+//    public static ViewAction setDate(final int year, final int month, final int day) {
+//        return new ViewAction() {
+//            @Override
+//            public Matcher<View> getConstraints() {
+//                return isAssignableFrom(DatePicker.class);
+//            }
+//
+//            @Override
+//            public String getDescription() {
+//                return "Set the date to " + year + "-" + (month + 1) + "-" + day;
+//            }
+//
+//            @Override
+//            public void perform(UiController uiController, View view) {
+//                DatePicker datePicker = (DatePicker) view;
+//                datePicker.updateDate(year, month, day);
+//            }
+//        };
+//    }
+//
+//
+//}

--- a/code/app/src/androidTest/java/com/baobook/baobook/controller/AuthHelperTest.java
+++ b/code/app/src/androidTest/java/com/baobook/baobook/controller/AuthHelperTest.java
@@ -15,6 +15,7 @@ import com.example.baobook.controller.AuthHelper;
 import com.example.baobook.constant.FirestoreConstants;
 import com.example.baobook.exception.AuthenticationException;
 import com.example.baobook.exception.UsernameAlreadyExistsException;
+import com.example.baobook.model.MoodEvent;
 import com.example.baobook.model.User;
 import com.google.firebase.firestore.FirebaseFirestore;
 
@@ -23,6 +24,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
@@ -42,7 +45,7 @@ public class AuthHelperTest {
             // 10.0.2.2 is the special IP address to connect to the 'localhost' of
             // the host computer from an Android emulator.
             db.useEmulator("10.0.2.2", 8080);
-            FirestoreTestUtils.clearFirestoreCollection(FirestoreConstants.COLLECTION_USERS);
+            FirestoreTestUtils.clearFirestoreCollection(FirestoreConstants.COLLECTION_USERS).join();
         } catch (IllegalStateException e) {
             // pass
         } catch (Exception e) {
@@ -54,7 +57,7 @@ public class AuthHelperTest {
     public void tearDown() throws RuntimeException, InterruptedException {
         // Clear SharedPreferences.
         sharedPreferences.edit().clear().apply();
-        FirestoreTestUtils.clearFirestoreCollection(FirestoreConstants.COLLECTION_USERS);
+        FirestoreTestUtils.clearFirestoreCollection(FirestoreConstants.COLLECTION_USERS).join();
     }
 
     @Test

--- a/code/app/src/androidTest/java/com/baobook/baobook/controller/UserHelperTest.java
+++ b/code/app/src/androidTest/java/com/baobook/baobook/controller/UserHelperTest.java
@@ -35,16 +35,7 @@ public class UserHelperTest {
         db = FirebaseFirestore.getInstance();
         try {
             db.useEmulator("10.0.2.2", 8080);
-
-            FirestoreTestUtils.clearFirestoreCollection(FirestoreConstants.COLLECTION_USERS);
-            List<User> testUsers = Arrays.asList(
-                    new User(username1, "password"),
-                    new User(username2, "password")
-            );
-
-            for (User user : testUsers) {
-                setUserInUsersCollection(user).join();
-            }
+            resetDatabase();
         } catch (IllegalStateException e) {
             // pass
         } catch (Exception e) {
@@ -54,7 +45,7 @@ public class UserHelperTest {
 
     @After
     public void tearDown() {
-        FirestoreTestUtils.clearFirestoreCollection(FirestoreConstants.COLLECTION_USERS);
+        resetDatabase();
     }
 
     @Test
@@ -182,4 +173,16 @@ public class UserHelperTest {
 
         return future;
     }
+
+    private void resetDatabase() {
+        FirestoreTestUtils.clearFirestoreCollection(FirestoreConstants.COLLECTION_USERS).join();
+        List<User> testUsers = Arrays.asList(
+                new User(username1, "password"),
+                new User(username2, "password")
+        );
+        for (User user : testUsers) {
+            setUserInUsersCollection(user).join();
+        }
+    }
+
 }

--- a/code/app/src/main/AndroidManifest.xml
+++ b/code/app/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
             android:exported="true">
         </activity>
         <activity
-            android:name=".model.MoodHistory"
+            android:name=".MoodHistory"
             android:exported="false" />
         <activity
             android:name=".Home"

--- a/code/app/src/main/java/com/example/baobook/Home.java
+++ b/code/app/src/main/java/com/example/baobook/Home.java
@@ -14,8 +14,9 @@ import androidx.core.graphics.Insets;
 import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 
+import com.example.baobook.constant.FirestoreConstants;
+import com.example.baobook.controller.MoodEventHelper;
 import com.example.baobook.model.MoodEvent;
-import com.example.baobook.model.MoodHistory;
 import com.example.baobook.model.MoodHistoryManager;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
 import com.google.firebase.firestore.CollectionReference;
@@ -26,20 +27,20 @@ public class Home extends AppCompatActivity {
     // Firestore instance and reference
     private FirebaseFirestore db;
     private CollectionReference moodsRef;
+    private MoodEventHelper moodEventHelper = new MoodEventHelper();
 
     // ActivityResultLauncher to handle the result from AddMoodActivity
-    private final ActivityResultLauncher<Intent> addMoodLauncher = registerForActivityResult(
-            new ActivityResultContracts.StartActivityForResult(),
-            result -> {
-                if (result.getResultCode() == RESULT_OK && result.getData() != null) {
-                    // Get the new mood event from AddMoodActivity
-                    MoodEvent mood = (MoodEvent) result.getData().getSerializableExtra("moodEvent");
-                    if (mood != null) {
-                        // Add the mood to Firestore
-                        Toast.makeText(this, "Mood added!", Toast.LENGTH_SHORT).show();
+    private final ActivityResultLauncher<Intent> addMoodLauncher =
+            registerForActivityResult(new ActivityResultContracts.StartActivityForResult(),
+                    result -> {
+                        if (result.getResultCode() == RESULT_OK && result.getData() != null) {
+                            MoodEvent mood = (MoodEvent) result.getData().getSerializableExtra("moodEvent");
+                            if (mood != null) {
+                                Toast.makeText(this, "Mood added!", Toast.LENGTH_SHORT).show();
+                            }
+                        }
                     }
-                }
-            });
+            );
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -48,7 +49,7 @@ public class Home extends AppCompatActivity {
 
         // Initialize Firestore
         db = FirebaseFirestore.getInstance();
-        moodsRef = db.collection("moodEvents");
+        moodsRef = db.collection(FirestoreConstants.COLLECTION_MOOD_EVENTS);
 
         // Enable edge-to-edge display
         EdgeToEdge.enable(this);

--- a/code/app/src/main/java/com/example/baobook/MoodEventArrayAdapter.java
+++ b/code/app/src/main/java/com/example/baobook/MoodEventArrayAdapter.java
@@ -17,7 +17,8 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.example.baobook.model.MoodEvent;
-import java.text.SimpleDateFormat;
+
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Locale;
 
@@ -54,8 +55,8 @@ public class MoodEventArrayAdapter extends ArrayAdapter<MoodEvent> {
 
         if (moodEvent != null) {
             // Format date and time
-            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault());
-            SimpleDateFormat timeFormat = new SimpleDateFormat("HH:mm", Locale.getDefault());
+            DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.getDefault());
+            DateTimeFormatter timeFormat = DateTimeFormatter.ofPattern("HH:mm", Locale.getDefault());
 
             // Set mood state with emoji and color using MoodUtils
             String moodString = moodEvent.getMood().toString();
@@ -63,8 +64,9 @@ public class MoodEventArrayAdapter extends ArrayAdapter<MoodEvent> {
             moodText.setTextColor(MoodUtils.getMoodColor(moodString)); // Set color
 
             // Set date, time, and description
-            dateText.setText("Date: " + dateFormat.format(moodEvent.getDate()));
-            timeText.setText("Time: " + timeFormat.format(moodEvent.getTime()));
+            dateText.setText("Date: " + dateFormat.format(moodEvent.getDateTime().toLocalDate()));
+            timeText.setText("Time: " + timeFormat.format(moodEvent.getDateTime().toLocalTime()));
+            descriptionText.setText("Trigger: " + moodEvent.getDescription());
 
             String description = moodEvent.getDescription();
             if (description == null || description.trim().isEmpty()) {
@@ -75,8 +77,6 @@ public class MoodEventArrayAdapter extends ArrayAdapter<MoodEvent> {
             }
 
             social.setText("Social: " + moodEvent.getSocial());
-
-
 
             if (moodEvent.getBase64image() != null && !moodEvent.getBase64image().isEmpty()) {
                 Log.d("MoodEventArrayAdapter", "Base64 Image Found: " + moodEvent.getBase64image().substring(0, 30)); // Show only first 30 chars
@@ -89,10 +89,7 @@ public class MoodEventArrayAdapter extends ArrayAdapter<MoodEvent> {
 
             GradientDrawable drawable = (GradientDrawable) rootLayout.getBackground();
             if (drawable != null) {
-
                 drawable.setStroke(5, MoodUtils.getMoodColor(moodString)); // Set border color
-                //drawable.setStroke(2, MoodUtils.getMoodColor(moodString)); // Set border color
-
             }
         }
 

--- a/code/app/src/main/java/com/example/baobook/MoodEventOptionsFragment.java
+++ b/code/app/src/main/java/com/example/baobook/MoodEventOptionsFragment.java
@@ -21,7 +21,10 @@ import androidx.fragment.app.DialogFragment;
 
 import com.example.baobook.model.MoodEvent;
 
+import java.text.DateFormat;
 import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
 import java.util.Locale;
 
 public class MoodEventOptionsFragment extends DialogFragment {
@@ -73,14 +76,14 @@ public class MoodEventOptionsFragment extends DialogFragment {
             Button deleteButton = view.findViewById(R.id.button_delete_mood);
 
             moodState.setText(moodEvent.getMood().toString());
-            moodSocial.setText(moodEvent.getSocial());
+            moodSocial.setText(moodEvent.getSocial().toString());
             moodTrigger.setText(moodEvent.getDescription());
 
-            SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd", Locale.getDefault());
-            SimpleDateFormat timeFormat = new SimpleDateFormat("HH:mm", Locale.getDefault());
+            DateTimeFormatter dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.getDefault());
+            DateTimeFormatter timeFormat = DateTimeFormatter.ofPattern("HH:mm", Locale.getDefault());
 
-            moodDate.setText(dateFormat.format(moodEvent.getDate()));
-            moodTime.setText(timeFormat.format(moodEvent.getTime()));
+            moodDate.setText(dateFormat.format(moodEvent.getDateTime()));
+            moodTime.setText(timeFormat.format(moodEvent.getDateTime()));
 
             if (moodEvent.getBase64image() != null && !moodEvent.getBase64image().isEmpty()) {
                 moodImage.setImageBitmap(base64ToBitmap(moodEvent.getBase64image()));

--- a/code/app/src/main/java/com/example/baobook/UserProfileActivity.java
+++ b/code/app/src/main/java/com/example/baobook/UserProfileActivity.java
@@ -1,5 +1,6 @@
 package com.example.baobook;
 
+import com.example.baobook.controller.FirestoreHelper;
 import com.example.baobook.model.MoodEvent;
 
 import android.content.Intent;
@@ -43,8 +44,7 @@ public class UserProfileActivity extends AppCompatActivity implements
     public void onMoodEdited(MoodEvent updatedMoodEvent) {
         for (int i = 0; i < dataList.size(); i++) {
             MoodEvent mood = dataList.get(i);
-            if (mood.getDate().equals(updatedMoodEvent.getDate()) &&
-                    mood.getTime().equals(updatedMoodEvent.getTime())) {
+            if (mood.getId().equals(updatedMoodEvent.getId())) {
                 dataList.set(i, updatedMoodEvent);
                 moodArrayAdapter.notifyDataSetChanged();
                 Toast.makeText(this, "Mood Event updated!", Toast.LENGTH_SHORT).show();
@@ -127,7 +127,7 @@ public class UserProfileActivity extends AppCompatActivity implements
         Button moodHistoryButton = findViewById(R.id.mood_history_button);
         moodHistoryButton.setOnClickListener(v -> {
             // Launch MoodHistory activity
-            Intent intent = new Intent(UserProfileActivity.this, com.example.baobook.model.MoodHistory.class);
+            Intent intent = new Intent(UserProfileActivity.this, MoodHistory.class);
             startActivity(intent);
         });
     }

--- a/code/app/src/main/java/com/example/baobook/controller/FirestoreHelper.java
+++ b/code/app/src/main/java/com/example/baobook/controller/FirestoreHelper.java
@@ -1,4 +1,4 @@
-package com.example.baobook;
+package com.example.baobook.controller;
 
 import static android.content.Context.MODE_PRIVATE;
 
@@ -8,11 +8,10 @@ import android.util.Log;
 import android.widget.Toast;
 
 
+import com.example.baobook.MoodEventArrayAdapter;
 import com.example.baobook.model.MoodEvent;
 import com.example.baobook.model.User;
-import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.FirebaseFirestore;
-import com.google.firebase.firestore.Source;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/code/app/src/main/java/com/example/baobook/model/MoodEvent.java
+++ b/code/app/src/main/java/com/example/baobook/model/MoodEvent.java
@@ -1,100 +1,80 @@
 package com.example.baobook.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.firebase.Timestamp;
+import com.google.firebase.firestore.Exclude;
+import com.google.firebase.firestore.PropertyName;
 
 import java.io.Serializable;
+import java.time.OffsetDateTime;
+import java.util.Objects;
 import java.util.Date;
 import java.sql.Time;
 import java.util.UUID;
 
 public class MoodEvent implements Serializable {
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
     private String username;
     private String id; // Unique ID for Firestore
     private Mood mood;
-    private Date date; // Use java.util.Date for date
-    private Date time; // Use java.util.Date for time
+    private long timestamp; // For deserializing from Firestore
+
+    @Exclude
+    @JsonIgnore
+    private OffsetDateTime dateTime;
     private String description;
-    private String social;
     private String base64image;
+    private SocialSetting social;
 
     // No-argument constructor required for Firestore
     public MoodEvent() {}
 
-    public MoodEvent(String username, String id, Mood mood, Date date, Date time, String description, String social, String base64image) {
+    public MoodEvent(String username, String id, Mood mood, OffsetDateTime dateTime, String description, SocialSetting social, String base64image) {
         this.username = username;
         this.id = id;
         this.mood = mood;
-        this.date = date;
-        this.time = time;
+        this.timestamp = dateTime.getNano();
+        this.dateTime = dateTime;
         this.description = description;
         this.social = social;
         this.base64image = base64image;
     }
 
-    // Constructor for testing - converts java.sql.Time to java.util.Date
-    public MoodEvent(String username, Mood mood, Date date, Time time, String description) {
-        this.username = username;
-        this.id = UUID.randomUUID().toString();
-        this.mood = mood;
-        this.date = date;
-        this.time = new Date(time.getTime()); // Convert sql.Time to util.Date
-        this.description = description;
-        this.social = "ALONE";
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getUsername() { return username; }
+
+    public Mood getMood() { return mood; }
+    public void setMood(Mood mood) { this.mood = mood; }
+
+    @Exclude
+    public OffsetDateTime getDateTime() { return dateTime; }
+
+    @Exclude
+    public void setDateTime(OffsetDateTime dateTime) {
+        this.dateTime = dateTime;
+        this.timestamp = dateTime.getNano();
     }
 
-    public String getId() {
-        return id;
+    @PropertyName("timestamp")
+    public long getDateTimeInNano() {
+        return timestamp;
+    }
+    @PropertyName("timestamp")
+    public void setDateTimeInNano(long timestamp) {
+        this.timestamp = timestamp;
+        this.dateTime = OffsetDateTime.ofInstant(java.time.Instant.ofEpochMilli(timestamp), java.time.ZoneOffset.UTC);
     }
 
-    public void setId(String id) {
-        this.id = id;
-    }
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
 
-    public String getUsername() {
-        return username;
-    }
-
-    public Mood getMood() {
-        return mood;
-    }
-
-    public void setMood(Mood mood) {
-        this.mood = mood;
-    }
-
-    public Date getDate() {
-        return date;
-    }
-
-    public void setDate(Date date) {
-        this.date = date;
-    }
-
-    public Date getTime() {
-        return time;
-    }
-
-    public void setTime(Date time) {
-        this.time = time;
-    }
-
-    public String getDescription() {
-        return description;
-    }
-
-    public void setDescription(String description) {
-        this.description = description;
-    }
-
-    public String getSocial() {
-        return social;
-    }
-
-    public void setSocial(String social) {
-        this.social = social;
-    }
+    public SocialSetting getSocial() { return social; }
+    public void setSocial(SocialSetting social) { this.social = social; }
 
     public String getBase64image() {return base64image;}
 
@@ -104,32 +84,27 @@ public class MoodEvent implements Serializable {
      * Edits the current mood event with new details.
      *
      * @param newMood       The new mood (e.g., "Happy", "Sad", etc.).
-     * @param newDate       The new date for the event.
-     * @param newTime       The new time for the event.
+     * @param newDateTime  The new date and time for the event.
      * @param newDescription The new description for the event.
+     * @param newSocial     The new social setting for the event.
      */
-    public void editMoodEvent(Mood newMood, Date newDate, Time newTime, String newDescription) {
+    public void editMoodEvent(Mood newMood, OffsetDateTime newDateTime, String newDescription, SocialSetting newSocial) {
         setMood(newMood);
-        setDate(newDate);
-        setTime(new Date(newTime.getTime()));
-        setDescription(newDescription);
-    }
-
-    public void editMoodEvent(Mood newMood, Date newDate, Date newTime, String newDescription, String newSocial) {
-        setMood(newMood);
-        setDate(newDate);
-        setTime(new Date(newTime.getTime()));
+        setDateTime(newDateTime);
         setDescription(newDescription);
         setSocial(newSocial);
     }
 
     @Override
     public boolean equals(Object obj) {
-        if (obj.getClass() == MoodEvent.class) {
-            MoodEvent moodEvent = (MoodEvent) obj;
-            return this.getId().equals(moodEvent.getId());  // same MoodEvent id
-        }
-        return false;
+        if (this == obj) return true;
+        if (obj == null || getClass() != obj.getClass()) return false;
+        MoodEvent other = (MoodEvent) obj;
+        return id.equals(other.getId())
+                && mood == other.getMood()
+                && timestamp == other.getDateTimeInNano()
+                && description.equals(other.getDescription())
+                && social == other.getSocial();
     }
 
     @Override
@@ -137,9 +112,7 @@ public class MoodEvent implements Serializable {
         try {
             return objectMapper.writeValueAsString(this);
         } catch (JsonProcessingException e) {
-            throw new RuntimeException("Failed to map MoodEvent to string.");
+            throw new RuntimeException("Failed to map MoodEvent to JSON string.");
         }
     }
-
-
 }

--- a/code/app/src/main/java/com/example/baobook/model/MoodHistoryManager.java
+++ b/code/app/src/main/java/com/example/baobook/model/MoodHistoryManager.java
@@ -1,8 +1,11 @@
 package com.example.baobook.model;
 
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
+import java.util.List;
 
 /**
  * Manager class for handling mood history globally.
@@ -29,6 +32,11 @@ public class MoodHistoryManager {
         moodList.add(mood);
     }
 
+    // Add a single mood to the manager's list
+    public void addAllMoods(List<MoodEvent> moods) {
+        moodList.addAll(moods);
+    }
+
     // Return the raw list (unfiltered)
     public ArrayList<MoodEvent> getMoodList() {
         return moodList;
@@ -41,13 +49,7 @@ public class MoodHistoryManager {
 
     // Sort the manager's list in reverse chronological order
     public void sortByDate() {
-        Collections.sort(moodList, (m1, m2) -> {
-            int dateComparison = m2.getDate().compareTo(m1.getDate());
-            if (dateComparison != 0) {
-                return dateComparison;
-            }
-            return m2.getTime().compareTo(m1.getTime());
-        });
+        moodList.sort(Comparator.comparing(MoodEvent::getDateTime).reversed());
     }
 
     // Existing single-mood filter (optional)
@@ -88,11 +90,11 @@ public class MoodHistoryManager {
 
         // 2) Filter by last 7 days
         if (filterRecentWeek) {
-            long oneWeekAgo = System.currentTimeMillis() - (7L * 24 * 60 * 60 * 1000);
+            OffsetDateTime oneWeekAgo = OffsetDateTime.now().minusWeeks(1);
             ArrayList<MoodEvent> toRemove = new ArrayList<>();
             for (MoodEvent me : temp) {
-                Date dateTime = combineDateAndTime(me.getDate(), me.getTime());
-                if (dateTime.getTime() < oneWeekAgo) {
+                OffsetDateTime dateTime = me.getDateTime();
+                if (dateTime.isBefore(oneWeekAgo)) {
                     toRemove.add(me);
                 }
             }
@@ -114,11 +116,7 @@ public class MoodHistoryManager {
         }
 
         // Sort descending by date/time
-        Collections.sort(temp, (m1, m2) -> {
-            int dateComparison = m2.getDate().compareTo(m1.getDate());
-            if (dateComparison != 0) return dateComparison;
-            return m2.getTime().compareTo(m1.getTime());
-        });
+        temp.sort(Comparator.comparing(MoodEvent::getDateTime).reversed());
 
         return temp;
     }
@@ -167,13 +165,5 @@ public class MoodHistoryManager {
             }
         }
         return dp[len1][len2];
-    }
-
-    /**
-     * If your MoodEvent stores date and time separately,
-     * combine them here. For now, simply return the date.
-     */
-    private Date combineDateAndTime(Date date, Date time) {
-        return date;
     }
 }

--- a/code/app/src/main/java/com/example/baobook/model/SocialSetting.java
+++ b/code/app/src/main/java/com/example/baobook/model/SocialSetting.java
@@ -4,7 +4,7 @@ import androidx.annotation.NonNull;
 
 public enum SocialSetting {
     ALONE("Alone"),
-    SMALL_GROUP("Small Group"),  // 2 to several people
+    DUO("Duo"),  // 2 to several people
     CROWD("Crowd");
 
     private final String prettyName;

--- a/code/app/src/main/java/com/example/baobook/model/User.java
+++ b/code/app/src/main/java/com/example/baobook/model/User.java
@@ -59,7 +59,7 @@ public class User {
         }
 
         if (!followers.contains(follower)) {
-            followers.add(username);
+            followers.add(follower);
         }
     }
 
@@ -73,7 +73,7 @@ public class User {
         }
 
         if (!followings.contains(following)) {
-            followings.add(username);
+            followings.add(following);
         }
     }
 
@@ -81,9 +81,9 @@ public class User {
         followings.remove(following);
     }
 
-    public void followUser(User user) {
-        user.addFollower(username);
-        addFollowing(user.getUsername());
+    public void followUser(User otherUser) {
+        otherUser.addFollower(username);
+        addFollowing(otherUser.getUsername());
     }
 
     public void unfollowUser(User user) {

--- a/code/app/src/test/java/com/baobook/baobook/model/MoodEventTest.java
+++ b/code/app/src/test/java/com/baobook/baobook/model/MoodEventTest.java
@@ -6,41 +6,35 @@ import com.example.baobook.model.Mood;
 import com.example.baobook.model.MoodEvent;
 import com.example.baobook.model.SocialSetting;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 
-import org.junit.runners.Parameterized;
-import org.mockito.Mock;
-
-import java.sql.Time;
+import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Date;
 
 @RunWith(JUnitParamsRunner.class)
 public class MoodEventTest {
-
+    private static final String id = "0";
     private static final String username = "username";
     private static final Mood mood = Mood.HAPPINESS;
-    private static final Date date = new Date("July 20, 2012");
-    private static final Time time = Time.valueOf("00:00:00");
+    private static final OffsetDateTime dateTime = OffsetDateTime.parse("2012-07-20T12:00:00Z");
     private static final String description = "just ate a pizza pop";
-
+    private static final SocialSetting socialSetting = SocialSetting.ALONE;
 
     @Test
     @Parameters(method="getMoods")
     public void getMood_shouldReturnExpectedMood(Mood mood) {
-        MoodEvent cut = new MoodEvent(username, mood, date, time, description);
+        MoodEvent cut = new MoodEvent(username, id, mood, dateTime, description, socialSetting, "");
         assertEquals(mood, cut.getMood());
     }
 
     @Test
     @Parameters(method="getMoodTransitions")
     public void setMood_shouldChangeMood(Mood mood, Mood newMood) {
-        MoodEvent cut = new MoodEvent(username, mood, date, time, description);
+        MoodEvent cut = new MoodEvent(username, id, mood, dateTime, description, socialSetting, "");
         assertEquals(mood, cut.getMood());
 
         cut.setMood(newMood);
@@ -48,42 +42,25 @@ public class MoodEventTest {
     }
 
     @Test
-    public void getDate_shouldReturnExpectedDate() {
-        MoodEvent cut = new MoodEvent(username, mood, date, time, description);
-        assertEquals(date, cut.getDate());
+    public void getTimestamp_shouldReturnExpectedTimestamp() {
+        MoodEvent cut = new MoodEvent(username, id, mood, dateTime, description, socialSetting, "");
+        assertEquals(dateTime, cut.getDateTime());
     }
 
     @Test
-    public void setDate_shouldChangeDate() {
-        Date newDate = new Date("March 4, 2025");
+    public void setTimestamp_shouldChangeTimestamp() {
+        OffsetDateTime newTimestamp = OffsetDateTime.parse("2025-03-04T14:30:00Z");
 
-        MoodEvent cut = new MoodEvent(username, mood, date, time, description);
-        assertEquals(date, cut.getDate());
+        MoodEvent cut = new MoodEvent(username, id, mood, dateTime, description, socialSetting, "");
+        assertEquals(dateTime, cut.getDateTime());
 
-        cut.setDate(newDate);
-        assertEquals(newDate, cut.getDate());
-    }
-
-    @Test
-    public void getTime_shouldReturnExpectedTime() {
-        MoodEvent cut = new MoodEvent(username, mood, date, time, description);
-        assertEquals(time, cut.getTime());
-    }
-
-    @Test
-    public void setTime_shouldChangeTime() {
-        Time newTime = Time.valueOf("12:34:56");
-
-        MoodEvent cut = new MoodEvent(username, mood, date, time, description);
-        assertEquals(time, cut.getTime());
-
-        cut.setTime(newTime);
-        assertEquals(newTime, cut.getTime());
+        cut.setDateTime(newTimestamp);
+        assertEquals(newTimestamp, cut.getDateTime());
     }
 
     @Test
     public void getDescription_shouldReturnExpectedDescription() {
-        MoodEvent cut = new MoodEvent(username, mood, date, time, description);
+        MoodEvent cut = new MoodEvent(username, id, mood, dateTime, description, socialSetting, "");
         assertEquals(description, cut.getDescription());
     }
 
@@ -91,7 +68,7 @@ public class MoodEventTest {
     public void setDescription_shouldChangeDescription() {
         String newDescription = "i'm hungry";
 
-        MoodEvent cut = new MoodEvent(username, mood, date, time, description);
+        MoodEvent cut = new MoodEvent(username, id, mood, dateTime, description, socialSetting, "");
         assertEquals(description, cut.getDescription());
 
         cut.setDescription(newDescription);
@@ -100,22 +77,21 @@ public class MoodEventTest {
 
     @Test
     public void editMoodEvent_shouldChangeAllAttributes() {
-        MoodEvent cut = new MoodEvent(username, mood, date, time, description);
+        MoodEvent cut = new MoodEvent(username, id, mood, dateTime, description, socialSetting, "");
         assertEquals(mood, cut.getMood());
-        assertEquals(date, cut.getDate());
-        assertEquals(time, cut.getTime());
+        assertEquals(dateTime, cut.getDateTime());
         assertEquals(description, cut.getDescription());
 
         Mood newMood = Mood.ANGER;
-        Date newDate = new Date("March 4, 2025");
-        Time newTime = Time.valueOf("12:34:56");
+        OffsetDateTime newTimestamp = OffsetDateTime.parse("2025-03-04T14:30:00Z");
         String newDescription = "i'm hungry";
+        SocialSetting newSocial = SocialSetting.DUO;
 
-        cut.editMoodEvent(newMood, newDate, newTime, newDescription);
+        cut.editMoodEvent(newMood, newTimestamp, newDescription, newSocial);
         assertEquals(newMood, cut.getMood());
-        assertEquals(newDate, cut.getDate());
-        assertEquals(newTime, cut.getTime());
+        assertEquals(newTimestamp, cut.getDateTime());
         assertEquals(newDescription, cut.getDescription());
+        assertEquals(newSocial, cut.getSocial());
     }
 
     public Collection<Mood> getMoods() {

--- a/code/app/src/test/java/com/baobook/baobook/model/MoodHistoryManagerTest.java
+++ b/code/app/src/test/java/com/baobook/baobook/model/MoodHistoryManagerTest.java
@@ -6,14 +6,16 @@ import static org.junit.Assert.assertTrue;
 import com.example.baobook.model.Mood;
 import com.example.baobook.model.MoodEvent;
 import com.example.baobook.model.MoodHistoryManager;
+import com.example.baobook.model.SocialSetting;
 
 import org.junit.Before;
 import org.junit.Test;
 
-import java.sql.Time;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.Date;
 
 /**
  * Tests for the MoodHistoryManager's functionality, including
@@ -23,6 +25,8 @@ public class MoodHistoryManagerTest {
 
     private MoodHistoryManager manager;
     private static final String TEST_USERNAME = "testUser"; // For our mock MoodEvents
+    private static final SocialSetting socialSetting = SocialSetting.ALONE;
+    private static final OffsetDateTime date = LocalDateTime.now().atOffset(ZoneOffset.UTC);
 
     @Before
     public void setUp() {
@@ -38,27 +42,20 @@ public class MoodHistoryManagerTest {
     @Test
     public void testSortMoodHistoryByDate_ReverseChronological() {
         // Create test dates
-        Calendar cal = Calendar.getInstance();
 
         // Create most recent date
-        cal.set(2024, Calendar.MARCH, 15, 10, 0);
-        Date date1 = cal.getTime();
-        Time time1 = new Time(cal.getTimeInMillis());
+        OffsetDateTime date1 = OffsetDateTime.of(2024, 3, 15, 10, 0, 0, 0, ZoneOffset.UTC);
 
         // Create middle date
-        cal.set(2024, Calendar.MARCH, 14, 15, 30);
-        Date date2 = cal.getTime();
-        Time time2 = new Time(cal.getTimeInMillis());
+        OffsetDateTime date2 = OffsetDateTime.of(2024, 3, 14, 15, 30, 0, 0, ZoneOffset.UTC);
 
         // Create oldest date
-        cal.set(2024, Calendar.MARCH, 13, 9, 45);
-        Date date3 = cal.getTime();
-        Time time3 = new Time(cal.getTimeInMillis());
+        OffsetDateTime date3 = OffsetDateTime.of(2024, 3, 13, 9, 45, 0, 0, ZoneOffset.UTC);
 
         // Add moods in random order
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.HAPPINESS, date2, time2, "Middle"));
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.SADNESS, date3, time3, "Oldest"));
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.ANGER, date1, time1, "Most Recent"));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "2", Mood.HAPPINESS, date2, "Middle", socialSetting, ""));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "1", Mood.SADNESS, date3, "Oldest", socialSetting, ""));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "3", Mood.ANGER, date1, "Most Recent", socialSetting, ""));
 
         // Sort the list
         manager.sortByDate();
@@ -70,56 +67,17 @@ public class MoodHistoryManagerTest {
         assertEquals("Oldest", sortedList.get(2).getDescription());
     }
 
-    @Test
-    public void testSortMoodHistoryByDate_SameDate_DifferentTimes() {
-        // Create a single date
-        Calendar cal = Calendar.getInstance();
-        cal.set(2024, Calendar.MARCH, 15);
-        Date sameDate = cal.getTime();
-
-        // Different times on that date
-        cal.set(Calendar.HOUR_OF_DAY, 14);
-        cal.set(Calendar.MINUTE, 30);
-        Time time1 = new Time(cal.getTimeInMillis()); // 14:30
-
-        cal.set(Calendar.HOUR_OF_DAY, 12);
-        cal.set(Calendar.MINUTE, 0);
-        Time time2 = new Time(cal.getTimeInMillis()); // 12:00
-
-        cal.set(Calendar.HOUR_OF_DAY, 9);
-        cal.set(Calendar.MINUTE, 15);
-        Time time3 = new Time(cal.getTimeInMillis()); // 09:15
-
-        // Add moods in random order
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.HAPPINESS, sameDate, time2, "Noon"));
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.SADNESS, sameDate, time3, "Morning"));
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.ANGER, sameDate, time1, "Afternoon"));
-
-        // Sort the list
-        manager.sortByDate();
-
-        // Should be [Afternoon (14:30), Noon (12:00), Morning (09:15)]
-        ArrayList<MoodEvent> sortedList = manager.getMoodList();
-        assertEquals("Afternoon", sortedList.get(0).getDescription());
-        assertEquals("Noon", sortedList.get(1).getDescription());
-        assertEquals("Morning", sortedList.get(2).getDescription());
-    }
-
     // ---------------------------------------------------------------------------------------------
     // filterByMood(...) Tests
     // ---------------------------------------------------------------------------------------------
 
     @Test
     public void testFilterByMood_SingleMoodType() {
-        Calendar cal = Calendar.getInstance();
-        Date date = cal.getTime();
-        Time time = new Time(cal.getTimeInMillis());
-
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.HAPPINESS, date, time, "Happy1"));
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.SADNESS, date, time, "Sad"));
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.HAPPINESS, date, time, "Happy2"));
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.ANGER, date, time, "Angry"));
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.HAPPINESS, date, time, "Happy3"));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "1", Mood.HAPPINESS, date, "Happy1", socialSetting, ""));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "2", Mood.SADNESS, date, "Sad", socialSetting, ""));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "3", Mood.HAPPINESS, date, "Happy2", socialSetting, ""));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "4", Mood.ANGER, date, "Angry", socialSetting, ""));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "5", Mood.HAPPINESS, date, "Happy3", socialSetting, ""));
 
         // Filter for happy moods
         ArrayList<MoodEvent> filteredList = manager.filterByMood(Mood.HAPPINESS);
@@ -133,12 +91,8 @@ public class MoodHistoryManagerTest {
 
     @Test
     public void testFilterByMood_NoMatchingMoods() {
-        Calendar cal = Calendar.getInstance();
-        Date date = cal.getTime();
-        Time time = new Time(cal.getTimeInMillis());
-
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.HAPPINESS, date, time, "Happy1"));
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.HAPPINESS, date, time, "Happy2"));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "1", Mood.HAPPINESS, date, "Happy1", socialSetting, ""));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "2", Mood.HAPPINESS, date, "Happy2", socialSetting, ""));
 
         // Filter for a different mood type
         ArrayList<MoodEvent> filteredList = manager.filterByMood(Mood.SADNESS);
@@ -162,14 +116,10 @@ public class MoodHistoryManagerTest {
     @Test
     public void testFilterByWord_PartialMatch() {
         // This checks partial substring matches for "hel"
-        Calendar cal = Calendar.getInstance();
-        Date date = cal.getTime();
-        Time time = new Time(cal.getTimeInMillis());
-
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.HAPPINESS, date, time, "hello world"));
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.SADNESS, date, time, "helipad stuff"));
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.FEAR, date, time, "my best friend"));
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.DISGUST, date, time, "Help me!"));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "1", Mood.HAPPINESS, date, "hello world", socialSetting, ""));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "2", Mood.SADNESS, date, "helipad stuff", socialSetting, ""));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "3", Mood.FEAR, date, "my best friend", socialSetting, ""));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "4", Mood.DISGUST, date, "Help me!", socialSetting, ""));
 
         // We'll not filter by mood or last7days => pass (null, false, "hel")
         ArrayList<MoodEvent> filtered = manager.getFilteredList(null, false, "hel");
@@ -189,12 +139,8 @@ public class MoodHistoryManagerTest {
     @Test
     public void testFilterByWord_NoPartialMatch() {
         // If the filter word doesn't appear at all => empty result
-        Calendar cal = Calendar.getInstance();
-        Date date = cal.getTime();
-        Time time = new Time(cal.getTimeInMillis());
-
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.HAPPINESS, date, time, "hello world"));
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.SADNESS, date, time, "helipad stuff"));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "1", Mood.HAPPINESS, date, "hello world", socialSetting, ""));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "2", Mood.SADNESS, date, "helipad stuff", socialSetting, ""));
 
         ArrayList<MoodEvent> filtered = manager.getFilteredList(null, false, "xyz");
         assertTrue("Expecting no matches for 'xyz'", filtered.isEmpty());
@@ -203,13 +149,9 @@ public class MoodHistoryManagerTest {
     @Test
     public void testFilterByWord_CaseInsensitivePartialMatch() {
         // If your code does case-insensitive matching, verify:
-        Calendar cal = Calendar.getInstance();
-        Date date = cal.getTime();
-        Time time = new Time(cal.getTimeInMillis());
-
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.HAPPINESS, date, time, "Hello World"));
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.SADNESS, date, time, "HELLO AGAIN"));
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.FEAR, date, time, "HeLium balloon"));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "1", Mood.HAPPINESS, date, "Hello World", socialSetting, ""));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "2", Mood.SADNESS, date, "HELLO AGAIN", socialSetting, ""));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "3", Mood.FEAR, date, "HeLium balloon", socialSetting, ""));
 
         ArrayList<MoodEvent> filtered = manager.getFilteredList(null, false, "hel");
 
@@ -217,15 +159,13 @@ public class MoodHistoryManagerTest {
         assertEquals("All 3 match ignoring case", 3, filtered.size());
     }
 
+
     @Test
     public void testFilterByWord_OneEditAway() {
-
         Calendar cal = Calendar.getInstance();
-        Date date = cal.getTime();
-        Time time = new Time(cal.getTimeInMillis());
         // User typed "helo," we want to match "hello."
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.HAPPINESS, date, time, "hello friend"));
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.HAPPINESS, date, time, "some other desc"));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "1", Mood.HAPPINESS, date, "hello friend", socialSetting, ""));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "2", Mood.HAPPINESS, date, "some other desc", socialSetting, ""));
 
         ArrayList<MoodEvent> filtered = manager.getFilteredList(null, false, "helo");
         assertEquals("Expect 'hello friend' to match 'helo' by 1 edit distance", 1, filtered.size());
@@ -235,12 +175,8 @@ public class MoodHistoryManagerTest {
     @Test
     public void testFilterByWord_EmptyString() {
         // If user enters empty => no word filtering => all remain
-        Calendar cal = Calendar.getInstance();
-        Date date = cal.getTime();
-        Time time = new Time(cal.getTimeInMillis());
-
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.ANGER, date, time, "hello test"));
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.HAPPINESS, date, time, "something"));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "1", Mood.ANGER, date, "hello test", socialSetting, ""));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "2", Mood.HAPPINESS, date, "something", socialSetting, ""));
 
         ArrayList<MoodEvent> filtered = manager.getFilteredList(null, false, "");
         assertEquals("Empty filter means no filtering, so all remain", 2, filtered.size());
@@ -255,14 +191,12 @@ public class MoodHistoryManagerTest {
     public void testGetFilteredList_Combined() {
         // We'll test a scenario with a mood = HAPPINESS, lastWeek = false, and word = "hello"
         // Add data, then see if we get the correct subset
-        Calendar cal = Calendar.getInstance();
-        Date date = cal.getTime();
-        Time time = new Time(cal.getTimeInMillis());
 
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.HAPPINESS, date, time, "hello world"));
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.HAPPINESS, date, time, "random text"));
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.ANGER, date, time, "hello friend"));
-        manager.addMood(new MoodEvent(TEST_USERNAME, Mood.HAPPINESS, date, time, "HELLO AGAIN"));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "1", Mood.HAPPINESS, date, "hello world", socialSetting, ""));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "2", Mood.HAPPINESS, date, "random text", socialSetting, ""));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "3", Mood.ANGER, date, "hello friend", socialSetting, ""));
+        manager.addMood(new MoodEvent(TEST_USERNAME, "4", Mood.HAPPINESS, date, "HELLO AGAIN", socialSetting, ""));
+
 
         // Filter: Mood=HAPPINESS, lastWeek=false, word="hello"
         ArrayList<MoodEvent> filtered = manager.getFilteredList(Mood.HAPPINESS, false, "hello");

--- a/code/firestore.indexes.json
+++ b/code/firestore.indexes.json
@@ -1,0 +1,4 @@
+{
+  "indexes": [],
+  "fieldOverrides": []
+}

--- a/code/firestore.rules
+++ b/code/firestore.rules
@@ -1,0 +1,19 @@
+rules_version = '2';
+
+service cloud.firestore {
+  match /databases/{database}/documents {
+
+    // This rule allows anyone with your Firestore database reference to view, edit,
+    // and delete all data in your Firestore database. It is useful for getting
+    // started, but it is configured to expire after 30 days because it
+    // leaves your app open to attackers. At that time, all client
+    // requests to your Firestore database will be denied.
+    //
+    // Make sure to write security rules for your app before that time, or else
+    // all client requests to your Firestore database will be denied until you Update
+    // your rules
+    match /{document=**} {
+      allow read, write: if request.time < timestamp.date(2025, 3, 26);
+    }
+  }
+}


### PR DESCRIPTION
- Implement MoodEventHelper.
- Refactor MoodHistory to use MoodEventHelper.
- Add SocialSetting enum.
- Use java.time to store date and time in MoodEvents.
- Use long timestamp to deserialize MoodEvent documents from Firestore.
- Fix flaky integration tests.